### PR TITLE
Add support for recognizing .ksh scripts and Arch Linux PKGBUILDs

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -1,6 +1,7 @@
 'fileTypes': [
   'sh'
   'bash'
+  'ksh'
   'zsh'
   'zshrc'
   'bashrc'
@@ -10,9 +11,10 @@
   'bash_logout'
   '.textmate_init'
   'npmrc'
+  'PKGBUILD'
 ]
-'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-'
-'name': 'Shell Script (Bash)'
+'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-'
+'name': 'Shell Script'
 'patterns': [
   {
     'include': '#comment'


### PR DESCRIPTION
This just changes the language filetypes to include .ksh, and Arch Linux's `PKGBUILD` files, which are used by `makepkg` for creating `pacman` packages.
In addition, it includes changing the name of the language to just be "Shell Script", to remove possible confusion that this language only works for `bash` shell scripts
