### PR TITLE
Fix issue with herestrings

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -534,30 +534,40 @@
   'herestring':
     'patterns': [
       {
-        'captures':
+        'begin': '(<<<)\s*((\'))'
+        'beginCaptures':
           '1':
             'name': 'keyword.operator.herestring.shell'
           '2':
-            'name': 'string.quoted.single.herestring.shell'
+            'name': 'string.quoted.single.shell'
           '3':
             'name': 'punctuation.definition.string.begin.shell'
-          '4':
+        'end': '(\')'
+        'endCaptures':
+          '0':
+            'name': 'string.quoted.single.shell'
+          '1':
             'name': 'punctuation.definition.string.end.shell'
-        'match': '(<<<)((\')[^\']*(\'))'
         'name': 'meta.herestring.shell'
+        'contentName': 'string.quoted.single.shell'
       }
       {
-        'captures':
+        'begin': '(<<<)\s*(("))'
+        'beginCaptures':
           '1':
             'name': 'keyword.operator.herestring.shell'
           '2':
-            'name': 'string.quoted.double.herestring.shell'
+            'name': 'string.quoted.double.shell'
           '3':
             'name': 'punctuation.definition.string.begin.shell'
-          '6':
+        'end': '(")'
+        'endCaptures':
+          '0':
+            'name': 'string.quoted.double.shell'
+          '1':
             'name': 'punctuation.definition.string.end.shell'
-        'match': '(<<<)((")(\\\\("|\\\\)|[^"])*("))'
         'name': 'meta.herestring.shell'
+        'contentName': 'string.quoted.double.shell'
       }
       {
         'captures':

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -128,7 +128,10 @@ describe "Shell session grammar", ->
       "string.quoted.single.shell": "'"
 
     for scope, delim of delimsByScope
-      tokens = grammar.tokenizeLines "$cmd <<<" + delim + "\nlorem ipsum" + delim
+      tokens = grammar.tokenizeLines """
+      $cmd <<<#{delim}
+      lorem ipsum#{delim}
+      """
       temporaryScopeHack(tokens)
 
       expect(tokens[0][0]).toEqual value: '$', scopes: ['variable.other.normal.shell', 'punctuation.definition.variable.shell']

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -121,3 +121,19 @@ describe "Shell session grammar", ->
 
     expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
     expect(tokens[1]).toEqual value: ' [ -f /var/log/messages ]', scopes: ['source.shell', 'meta.scope.if-block.shell']
+
+  it "tokenizes herestrings", ->
+    delimsByScope =
+      "string.quoted.double.shell": '"'
+      "string.quoted.single.shell": "'"
+
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines "$cmd <<<" + delim + "\nlorem ipsum" + delim
+      temporaryScopeHack(tokens)
+
+      expect(tokens[0][0]).toEqual value: '$', scopes: ['variable.other.normal.shell', 'punctuation.definition.variable.shell']
+      expect(tokens[0][1]).toEqual value: 'cmd', scopes: ['variable.other.normal.shell']
+      expect(tokens[0][3]).toEqual value: '<<<', scopes: ['meta.herestring.shell', 'keyword.operator.herestring.shell']
+      expect(tokens[0][4]).toEqual value: delim, scopes: ['meta.herestring.shell', scope, 'punctuation.definition.string.begin.shell']
+      expect(tokens[1][0]).toEqual value: 'lorem ipsum', scopes: ['meta.herestring.shell', scope]
+      expect(tokens[1][1]).toEqual value: delim, scopes: ['meta.herestring.shell', scope, 'punctuation.definition.string.end.shell']


### PR DESCRIPTION
This pull request fixes the issue with here strings reported in #7:
```bash
lukkit_help() {
    $cmd <<<'
    lukkit patch build | Build patches from build/'
}

lukkit_patch(){
    echo "Use: 'lukkit patch [apply|build]"
    exit 1
}
```
See [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-shellscript%2F9df628668e56fd41de2bd8655bcfa4651770ca54%2Fgrammars%2Fshell-unix-bash.cson&grammar_text=&code_source=from-text&code_url=&code=lukkit_help%28%29+{%0D%0A++++%24cmd+%3C%3C%3C%27%0D%0A++++lukkit+patch+build+|+Build+patches+from+build%2F%27%0D%0A}%0D%0A%0D%0Alukkit_patch%28%29{%0D%0A++++echo+%22Use%3A+%27lukkit+patch+[apply|build]%22%0D%0A++++exit+1%0D%0A}).

~~It loses `meta.herestring.shell` scopes but there can now be here strings on several lines.~~