### PR TITLE
Variable constructs can include strings

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -978,6 +978,9 @@
                 'name': 'punctuation.section.array.shell'
             'match': '(\\[)([^\\]]+)(\\])'
           }
+          {
+            'include': '#string'
+          }
         ]
       }
     ]

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -1,12 +1,15 @@
 describe "Shell session grammar", ->
   grammar = null
+  grammar_session = null
 
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage("language-shellscript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.shell-session")
+      grammar_session = atom.grammars.grammarForScopeName("text.shell-session")
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.shell")
 
   # Remove this and fix assertions when Atom is upgraded to first-mate 4.x on master
   temporaryScopeHack = (lines) ->
@@ -16,11 +19,11 @@ describe "Shell session grammar", ->
         scopes.splice(index, 1) if index >= 0
 
   it "parses the grammar", ->
-    expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe "text.shell-session"
+    expect(grammar_session).toBeDefined()
+    expect(grammar_session.scopeName).toBe "text.shell-session"
 
   it "tokenizes > prompts", ->
-    tokens = grammar.tokenizeLines('> echo $FOO')
+    tokens = grammar_session.tokenizeLines('> echo $FOO')
     temporaryScopeHack(tokens)
 
     expect(tokens[0][0].value).toBe '>'
@@ -33,7 +36,7 @@ describe "Shell session grammar", ->
     expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
 
   it "tokenizes $ prompts", ->
-    tokens = grammar.tokenizeLines('$ echo $FOO')
+    tokens = grammar_session.tokenizeLines('$ echo $FOO')
     temporaryScopeHack(tokens)
 
     expect(tokens[0][0].value).toBe '$'
@@ -46,7 +49,7 @@ describe "Shell session grammar", ->
     expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
 
   it "tokenizes pound prompts", ->
-    tokens = grammar.tokenizeLines('# echo $FOO')
+    tokens = grammar_session.tokenizeLines('# echo $FOO')
     temporaryScopeHack(tokens)
 
     expect(tokens[0][0].value).toBe '#'
@@ -59,7 +62,7 @@ describe "Shell session grammar", ->
     expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
 
   it "tokenizes % prompts", ->
-    tokens = grammar.tokenizeLines('% echo $FOO')
+    tokens = grammar_session.tokenizeLines('% echo $FOO')
     temporaryScopeHack(tokens)
 
     expect(tokens[0][0].value).toBe '%'
@@ -72,7 +75,7 @@ describe "Shell session grammar", ->
     expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
 
   it "tokenizes prompts with prefixes", ->
-    tokens = grammar.tokenizeLines('user@machine $ echo $FOO')
+    tokens = grammar_session.tokenizeLines('user@machine $ echo $FOO')
     temporaryScopeHack(tokens)
 
     expect(tokens[0][0].value).toBe 'user@machine'
@@ -91,8 +94,23 @@ describe "Shell session grammar", ->
     expect(tokens[0][4].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
 
   it "tokenizes shell output", ->
-    tokens = grammar.tokenizeLines('$ echo $FOO\nfoo')
+    tokens = grammar_session.tokenizeLines('$ echo $FOO\nfoo')
     temporaryScopeHack(tokens)
 
     expect(tokens[1][0].value).toBe 'foo'
     expect(tokens[1][0].scopes).toEqual ['text.shell-session', 'meta.output.shell-session']
+
+  it "", ->
+    tokens = grammar.tokenizeLines("${'root'}")
+    temporaryScopeHack(tokens)
+
+    expect(tokens[0][0].value).toBe "${"
+    expect(tokens[0][0].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[0][1].value).toBe "'"
+    expect(tokens[0][1].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
+    expect(tokens[0][2].value).toBe "root"
+    expect(tokens[0][2].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell']
+    expect(tokens[0][3].value).toBe "'"
+    expect(tokens[0][3].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
+    expect(tokens[0][4].value).toBe '}'
+    expect(tokens[0][4].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -8,7 +8,6 @@ describe "Shell session grammar", ->
 
     runs ->
       grammar_session = atom.grammars.grammarForScopeName("text.shell-session")
-    runs ->
       grammar = atom.grammars.grammarForScopeName("source.shell")
 
   # Remove this and fix assertions when Atom is upgraded to first-mate 4.x on master

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -104,13 +104,8 @@ describe "Shell session grammar", ->
     {tokens} = grammar.tokenizeLine("${'root'}")
     temporaryScopeHack(tokens)
 
-    expect(tokens[0].value).toBe "${"
-    expect(tokens[0].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
-    expect(tokens[1].value).toBe "'"
-    expect(tokens[1].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
-    expect(tokens[2].value).toBe "root"
-    expect(tokens[2].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell']
-    expect(tokens[3].value).toBe "'"
-    expect(tokens[3].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
-    expect(tokens[4].value).toBe '}'
-    expect(tokens[4].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[1]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
+    expect(tokens[2]).toEqual value: "root", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell']
+    expect(tokens[3]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -100,17 +100,17 @@ describe "Shell session grammar", ->
     expect(tokens[1][0].value).toBe 'foo'
     expect(tokens[1][0].scopes).toEqual ['text.shell-session', 'meta.output.shell-session']
 
-  it "", ->
-    tokens = grammar.tokenizeLines("${'root'}")
+  it "tokenizes strings inside variable constructs", ->
+    {tokens} = grammar.tokenizeLine("${'root'}")
     temporaryScopeHack(tokens)
 
-    expect(tokens[0][0].value).toBe "${"
-    expect(tokens[0][0].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
-    expect(tokens[0][2].value).toBe "root"
-    expect(tokens[0][2].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell']
-    expect(tokens[0][3].value).toBe "'"
-    expect(tokens[0][3].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
-    expect(tokens[0][4].value).toBe '}'
-    expect(tokens[0][4].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[0].value).toBe "${"
+    expect(tokens[0].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[1].value).toBe "'"
+    expect(tokens[1].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
+    expect(tokens[2].value).toBe "root"
+    expect(tokens[2].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell']
+    expect(tokens[3].value).toBe "'"
+    expect(tokens[3].scopes).toEqual ['variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
+    expect(tokens[4].value).toBe '}'
+    expect(tokens[4].scopes).toEqual ['variable.other.bracket.shell', 'punctuation.definition.variable.shell']


### PR DESCRIPTION
This pull request fixes an issue reported in #7:
```bash
DEFAULT_BOOT_ARGS=${DEFAULT_BOOT_ARGS:-'root=${boot_fs} rw rootwait ${video}'}
DEVICE_MAP=($DEVICE_MAP)
DEFAULT_DTB=${DEFAULT_DTB:-"newest"}
```
See [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-shellscript%2F29995b2ce14ec9c7e85cc22cc88853407595a5d1%2Fgrammars%2Fshell-unix-bash.cson&grammar_text=&code_source=from-text&code_url=&code=DEFAULT_BOOT_ARGS%3D%24{DEFAULT_BOOT_ARGS%3A-%27root%3D%24{boot_fs}+rw+rootwait+%24{video}%27}%0D%0ADEVICE_MAP%3D%28%24DEVICE_MAP%29%0D%0ADEFAULT_DTB%3D%24{DEFAULT_DTB%3A-%22newest%22}).