### PR TITLE
Fix error with if parameter of dd

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -751,7 +751,7 @@
         ]
       }
       {
-        'begin': '\\b(if)\\b'
+        'begin': '\\b(if)(?!\s*=)'
         'captures':
           '1':
             'name': 'keyword.control.shell'

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -627,7 +627,7 @@
   'keyword':
     'patterns': [
       {
-        'match': '\\b(?:if|then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return)\\b'
+        'match': '\\b(?:then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return)\\b'
         'name': 'keyword.control.shell'
       }
       {

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -108,3 +108,16 @@ describe "Shell session grammar", ->
     expect(tokens[2]).toEqual value: "root", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell']
     expect(tokens[3]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
     expect(tokens[4]).toEqual value: '}', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+
+  it "tokenizes if correctly when it's a parameter", ->
+    {tokens} = grammar.tokenizeLine('dd if=/dev/random of=/dev/null')
+    temporaryScopeHack(tokens)
+
+    expect(tokens[0]).toEqual value: 'dd if=/dev/random of=/dev/null', scopes: ['source.shell']
+
+  it "tokenizes if contruct", ->
+    {tokens} = grammar.tokenizeLine('if [ -f /var/log/messages ]')
+    temporaryScopeHack(tokens)
+
+    expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
+    expect(tokens[1]).toEqual value: ' [ -f /var/log/messages ]', scopes: ['source.shell', 'meta.scope.if-block.shell']


### PR DESCRIPTION
This pull request fixes an error reported in #5:
```bash
local r1=$(dd if=/dev/urandom bs=1)
ula_prefix="fd${r1}:${r2}:${r3}::/48"
```

See the [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-shellscript%2Ffix-if-error%2Fgrammars%2Fshell-unix-bash.cson&grammar_text=&code_source=from-text&code_url=&code=local+r1%3D%24%28dd+if%3D%2Fdev%2Furandom+bs%3D1%29%0D%0Aula_prefix%3D%22fd%24{r1}%3A%24{r2}%3A%24{r3}%3A%3A%2F48%22).
~~The `if` keyword is still highlighted~~ but at least it doesn't break the highlighting of the code after it.