### PR TITLE
Combine and improve specs

### DIFF
--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -43,7 +43,10 @@ describe "Shell session grammar", ->
     expect(tokens[4]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
   it "tokenizes shell output", ->
-    tokens = grammarSession.tokenizeLines('$ echo $FOO\nfoo')
+    tokens = grammarSession.tokenizeLines '''
+      $ echo $FOO
+      foo
+    '''
 
     expect(tokens[1][0]).toEqual value: 'foo', scopes: ['text.shell-session', 'meta.output.shell-session']
 

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -1,23 +1,19 @@
 describe "Shell session grammar", ->
   grammar = null
-  grammarSession = null
 
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage("language-shellscript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.shell")
-      grammarSession = atom.grammars.grammarForScopeName("text.shell-session")
+      grammar = atom.grammars.grammarForScopeName("text.shell-session")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe "source.shell"
-    expect(grammarSession).toBeDefined()
-    expect(grammarSession.scopeName).toBe "text.shell-session"
+    expect(grammar.scopeName).toBe "text.shell-session"
 
   it "tokenizes > prompts", ->
-    {tokens} = grammarSession.tokenizeLine('> echo $FOO')
+    {tokens} = grammar.tokenizeLine('> echo $FOO')
 
     expect(tokens[0]).toEqual value: '>', scopes: ['text.shell-session', 'punctuation.separator.prompt.shell-session']
     expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session', 'source.shell']
@@ -27,14 +23,14 @@ describe "Shell session grammar", ->
     prompts = ["$", "#", "%"]
 
     for delim in prompts
-      {tokens} = grammarSession.tokenizeLine(delim + ' echo $FOO')
+      {tokens} = grammar.tokenizeLine(delim + ' echo $FOO')
 
       expect(tokens[0]).toEqual value: delim, scopes: ['text.shell-session', 'punctuation.separator.prompt.shell-session']
       expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session']
       expect(tokens[2]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
   it "tokenizes prompts with prefixes", ->
-    {tokens} = grammarSession.tokenizeLine('user@machine $ echo $FOO')
+    {tokens} = grammar.tokenizeLine('user@machine $ echo $FOO')
 
     expect(tokens[0]).toEqual value: 'user@machine', scopes: ['text.shell-session', 'entity.other.prompt-prefix.shell-session']
     expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session']
@@ -43,29 +39,9 @@ describe "Shell session grammar", ->
     expect(tokens[4]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
   it "tokenizes shell output", ->
-    tokens = grammarSession.tokenizeLines '''
+    tokens = grammar.tokenizeLines """
       $ echo $FOO
       foo
-    '''
+    """
 
     expect(tokens[1][0]).toEqual value: 'foo', scopes: ['text.shell-session', 'meta.output.shell-session']
-
-  it "tokenizes strings inside variable constructs", ->
-    {tokens} = grammar.tokenizeLine("${'root'}")
-
-    expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
-    expect(tokens[1]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
-    expect(tokens[2]).toEqual value: "root", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell']
-    expect(tokens[3]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
-    expect(tokens[4]).toEqual value: '}', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
-
-  it "tokenizes if correctly when it's a parameter", ->
-    {tokens} = grammar.tokenizeLine('dd if=/dev/random of=/dev/null')
-
-    expect(tokens[0]).toEqual value: 'dd if=/dev/random of=/dev/null', scopes: ['source.shell']
-
-  it "tokenizes if as a keyword", ->
-    {tokens} = grammar.tokenizeLine('if [ -f /var/log/messages ]')
-
-    expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
-    expect(tokens[1]).toEqual value: ' [ -f /var/log/messages ]', scopes: ['source.shell', 'meta.scope.if-block.shell']

--- a/spec/shell-session-spec.coffee
+++ b/spec/shell-session-spec.coffee
@@ -1,107 +1,54 @@
 describe "Shell session grammar", ->
   grammar = null
-  grammar_session = null
+  grammarSession = null
 
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage("language-shellscript")
 
     runs ->
-      grammar_session = atom.grammars.grammarForScopeName("text.shell-session")
       grammar = atom.grammars.grammarForScopeName("source.shell")
-
-  # Remove this and fix assertions when Atom is upgraded to first-mate 4.x on master
-  temporaryScopeHack = (lines) ->
-    for tokens in lines
-      for {scopes} in tokens
-        index = scopes.indexOf('source.shell')
-        scopes.splice(index, 1) if index >= 0
+      grammarSession = atom.grammars.grammarForScopeName("text.shell-session")
 
   it "parses the grammar", ->
-    expect(grammar_session).toBeDefined()
-    expect(grammar_session.scopeName).toBe "text.shell-session"
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe "source.shell"
+    expect(grammarSession).toBeDefined()
+    expect(grammarSession.scopeName).toBe "text.shell-session"
 
   it "tokenizes > prompts", ->
-    tokens = grammar_session.tokenizeLines('> echo $FOO')
-    temporaryScopeHack(tokens)
+    {tokens} = grammarSession.tokenizeLine('> echo $FOO')
 
-    expect(tokens[0][0].value).toBe '>'
-    expect(tokens[0][0].scopes).toEqual ['text.shell-session', 'punctuation.separator.prompt.shell-session']
+    expect(tokens[0]).toEqual value: '>', scopes: ['text.shell-session', 'punctuation.separator.prompt.shell-session']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session', 'source.shell']
+    expect(tokens[2]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
-    expect(tokens[0][1].value).toBe ' '
-    expect(tokens[0][1].scopes).toEqual ['text.shell-session']
+  it "tokenizes $, pound, and % prompts", ->
+    prompts = ["$", "#", "%"]
 
-    expect(tokens[0][2].value).toBe 'echo'
-    expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
+    for delim in prompts
+      {tokens} = grammarSession.tokenizeLine(delim + ' echo $FOO')
 
-  it "tokenizes $ prompts", ->
-    tokens = grammar_session.tokenizeLines('$ echo $FOO')
-    temporaryScopeHack(tokens)
-
-    expect(tokens[0][0].value).toBe '$'
-    expect(tokens[0][0].scopes).toEqual ['text.shell-session', 'punctuation.separator.prompt.shell-session']
-
-    expect(tokens[0][1].value).toBe ' '
-    expect(tokens[0][1].scopes).toEqual ['text.shell-session']
-
-    expect(tokens[0][2].value).toBe 'echo'
-    expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
-
-  it "tokenizes pound prompts", ->
-    tokens = grammar_session.tokenizeLines('# echo $FOO')
-    temporaryScopeHack(tokens)
-
-    expect(tokens[0][0].value).toBe '#'
-    expect(tokens[0][0].scopes).toEqual ['text.shell-session', 'punctuation.separator.prompt.shell-session']
-
-    expect(tokens[0][1].value).toBe ' '
-    expect(tokens[0][1].scopes).toEqual ['text.shell-session']
-
-    expect(tokens[0][2].value).toBe 'echo'
-    expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
-
-  it "tokenizes % prompts", ->
-    tokens = grammar_session.tokenizeLines('% echo $FOO')
-    temporaryScopeHack(tokens)
-
-    expect(tokens[0][0].value).toBe '%'
-    expect(tokens[0][0].scopes).toEqual ['text.shell-session', 'punctuation.separator.prompt.shell-session']
-
-    expect(tokens[0][1].value).toBe ' '
-    expect(tokens[0][1].scopes).toEqual ['text.shell-session']
-
-    expect(tokens[0][2].value).toBe 'echo'
-    expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
+      expect(tokens[0]).toEqual value: delim, scopes: ['text.shell-session', 'punctuation.separator.prompt.shell-session']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session']
+      expect(tokens[2]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
   it "tokenizes prompts with prefixes", ->
-    tokens = grammar_session.tokenizeLines('user@machine $ echo $FOO')
-    temporaryScopeHack(tokens)
+    {tokens} = grammarSession.tokenizeLine('user@machine $ echo $FOO')
 
-    expect(tokens[0][0].value).toBe 'user@machine'
-    expect(tokens[0][0].scopes).toEqual ['text.shell-session', 'entity.other.prompt-prefix.shell-session']
-
-    expect(tokens[0][1].value).toBe ' '
-    expect(tokens[0][1].scopes).toEqual ['text.shell-session']
-
-    expect(tokens[0][2].value).toBe '$'
-    expect(tokens[0][2].scopes).toEqual ['text.shell-session', 'punctuation.separator.prompt.shell-session']
-
-    expect(tokens[0][3].value).toBe ' '
-    expect(tokens[0][3].scopes).toEqual ['text.shell-session']
-
-    expect(tokens[0][4].value).toBe 'echo'
-    expect(tokens[0][4].scopes).toEqual ['text.shell-session', 'support.function.builtin.shell']
+    expect(tokens[0]).toEqual value: 'user@machine', scopes: ['text.shell-session', 'entity.other.prompt-prefix.shell-session']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['text.shell-session']
+    expect(tokens[2]).toEqual value: '$', scopes: ['text.shell-session', 'punctuation.separator.prompt.shell-session']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['text.shell-session']
+    expect(tokens[4]).toEqual value: 'echo', scopes: ['text.shell-session', 'source.shell', 'support.function.builtin.shell']
 
   it "tokenizes shell output", ->
-    tokens = grammar_session.tokenizeLines('$ echo $FOO\nfoo')
-    temporaryScopeHack(tokens)
+    tokens = grammarSession.tokenizeLines('$ echo $FOO\nfoo')
 
-    expect(tokens[1][0].value).toBe 'foo'
-    expect(tokens[1][0].scopes).toEqual ['text.shell-session', 'meta.output.shell-session']
+    expect(tokens[1][0]).toEqual value: 'foo', scopes: ['text.shell-session', 'meta.output.shell-session']
 
   it "tokenizes strings inside variable constructs", ->
     {tokens} = grammar.tokenizeLine("${'root'}")
-    temporaryScopeHack(tokens)
 
     expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
     expect(tokens[1]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
@@ -111,13 +58,11 @@ describe "Shell session grammar", ->
 
   it "tokenizes if correctly when it's a parameter", ->
     {tokens} = grammar.tokenizeLine('dd if=/dev/random of=/dev/null')
-    temporaryScopeHack(tokens)
 
     expect(tokens[0]).toEqual value: 'dd if=/dev/random of=/dev/null', scopes: ['source.shell']
 
-  it "tokenizes if contruct", ->
+  it "tokenizes if as a keyword", ->
     {tokens} = grammar.tokenizeLine('if [ -f /var/log/messages ]')
-    temporaryScopeHack(tokens)
 
     expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
     expect(tokens[1]).toEqual value: ' [ -f /var/log/messages ]', scopes: ['source.shell', 'meta.scope.if-block.shell']

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -1,0 +1,33 @@
+describe "Shell script grammar", ->
+	grammar = null
+
+	beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-shellscript")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.shell")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe "source.shell"
+
+	it "tokenizes strings inside variable constructs", ->
+    {tokens} = grammar.tokenizeLine("${'root'}")
+
+    expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[1]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
+    expect(tokens[2]).toEqual value: "root", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell']
+    expect(tokens[3]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.end.shell']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
+
+  it "tokenizes if correctly when it's a parameter", ->
+    {tokens} = grammar.tokenizeLine('dd if=/dev/random of=/dev/null')
+
+    expect(tokens[0]).toEqual value: 'dd if=/dev/random of=/dev/null', scopes: ['source.shell']
+
+  it "tokenizes if as a keyword", ->
+    {tokens} = grammar.tokenizeLine('if [ -f /var/log/messages ]')
+
+    expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
+    expect(tokens[1]).toEqual value: ' [ -f /var/log/messages ]', scopes: ['source.shell', 'meta.scope.if-block.shell']

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -1,7 +1,7 @@
 describe "Shell script grammar", ->
-	grammar = null
+  grammar = null
 
-	beforeEach ->
+  beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage("language-shellscript")
 
@@ -12,7 +12,7 @@ describe "Shell script grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.shell"
 
-	it "tokenizes strings inside variable constructs", ->
+  it "tokenizes strings inside variable constructs", ->
     {tokens} = grammar.tokenizeLine("${'root'}")
 
     expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']


### PR DESCRIPTION
This PR almost halves the size of the specs file :arrow_down: :chart_with_downwards_trend:.

Changes:
* Separate `source.shell` tests into their own specs file, `shell-unix-bash-spec.coffee`
* No more `temporaryScopeHack`
* Test also for `source.shell`
* Use `tokenizeLines` only if necessary
* Combine (most of) the prompt tests into one test
* Combine two-line token assertions into one

Things to note:
* I couldn't also add the `>` test into the newly formed prompt test because it gets tokenized differently for some reason.  I'm pretty sure this is a bug and would like to get that fixed before this is merged for even more savings.