### PR TITLE
Combine the two prompt matches

### DIFF
--- a/grammars/shell-session.cson
+++ b/grammars/shell-session.cson
@@ -5,17 +5,6 @@
 ]
 'patterns': [
   {
-    'match': '^(>)(.*)$'
-    'captures':
-      '1':
-        'name': 'punctuation.separator.prompt.shell-session'
-      '2':
-        'name': 'source.shell'
-        'patterns': [
-          'include': 'source.shell'
-        ]
-  }
-  {
     'match': '(?x)
       ^
       (?:
@@ -30,7 +19,7 @@
         \\s*
       )
       (
-        [$#%]
+        [>$#%]
       )
       \\s+
       (.*)


### PR DESCRIPTION
This PR gets rid of the dedicated `>` prompt matcher and combines it with the other `[$#%]` one.  I don't really see a reason for `>` to be separated from the rest.

Alternatively, if there is in fact a good reason for this separation, another simple change so that the two matches tokenize identically would be to change the first regex to `^(>)\\s+(.*)$`.

Refs #16 which will test for this new behavior if it's merged (there's currently no way to test for this because of the `temporaryScopeHack` stuff).

(Also, L14 contains a null match.  Not sure if that's intended or not.)