### PR TITLE
Increase indentation after `then` rather than `if` and `elif`.

### DIFF
--- a/settings/language-shellscript.cson
+++ b/settings/language-shellscript.cson
@@ -2,5 +2,5 @@
   'editor':
     'commentStart': '# '
     'foldEndPattern': '^\\s*(\\}|(done|fi|esac)\\b)'
-    'increaseIndentPattern': '^\\s*(if|elif|else|case)\\b|^.*(\\{|\\b(do)\\b)$'
+    'increaseIndentPattern': '^\\s*(else|case)\\b|^.*(\\{|\\b(then|do)\\b)$'
     'decreaseIndentPattern': '^\\s*(\\}|(elif|else|fi|esac|done)\\b)'


### PR DESCRIPTION
`if` and `elif` are always followed by the `then` keyword. In one
common coding style, the `then` keyword is often included on the same
line as the condition, following a semicolon:
```sh
if condition; then
  ...indented body...
fi
```

Alternatively, a newline can be used instead of a semicolon:
```sh
if condition
then
  ...indented body...
fi
```

This is similar to `while` and `until` loops, which can also be
written in both styles with the `do` keyword:
```sh
while condition; do
  ...indented body...
done

# vs

while condition
do
  ...indented body...
done
```

Prior to this commit, the increaseIndentPattern regular expression
supported both styles for `while` and `until` loops, which both use the
`do` keyword, but it only supported the semicolon style for `if` and
`elif`.

By replacing `if` and `elif` with a `then`-matching alternation
mirroring that of the `do` keyword, both styles are supported since it
will always indent after the `then`.

This commit also uses boilerplate from language-c and
language-javascript packages for indentation specs, which is then used
for specs for both styles with the `do` and `then` keywords.

Note that this commit adds the enhancement discussed in #12.