### PR TITLE
Improve firstLineMatch pattern

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -21,7 +21,7 @@
   'cygport'
   'bats'
 ]
-'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-'
+'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-'
 'patterns': [
   {
     'include': '#comment'

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -21,7 +21,7 @@
   'cygport'
   'bats'
 ]
-'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-'
+'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|(?i)(?:^\\s*#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-)'
 'patterns': [
   {
     'include': '#comment'

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -21,7 +21,7 @@
   'cygport'
   'bats'
 ]
-'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|(?i)(?:^\\s*#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-)'
+'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|(?i:^\\s*#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-)'
 'patterns': [
   {
     'include': '#comment'


### PR DESCRIPTION
This PR makes three improvements to the grammar's `firstLineMatch` pattern:

* **Extend the hashbang's list of interpreters to include `rc`**<br/>[`rc`](https://en.wikipedia.org/wiki/Rc) is the main command-line interpreter for the Version 10 and Plan 9 Unix systems, and is used in the header  of every shell-script written for those systems. More info [here](http://doc.cat-v.org/plan_9/4th_edition/papers/rc).<br/><br/>
* **Amend Emacs modeline to ignore capitalisation**<br/>Emacs reads the mode assignment case-insensitively, so something like `-*- Mode: Shell-script` would fail to match.<br/><br/>
* **Skip preceding whitespace before the `#` symbol**<br/>If the first line was intended, the pattern failed.