### PR TITLE
Adding install file ext

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -18,6 +18,7 @@
   '.textmate_init'
   'npmrc'
   'PKGBUILD'
+  'install'
   'cygport'
   'bats'
 ]


### PR DESCRIPTION
`.install` files (e.g., gvim.install for gVim) are used by PKGBUILDs to install peri-, post- and pre- installation checks and actions.