### PR TITLE
Adding zsh-theme ext

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -5,6 +5,7 @@
   'bash'
   'ksh'
   'zsh'
+  'zsh-theme'
   'zshenv'
   'zlogin'
   'zlogout'


### PR DESCRIPTION
In this commit I am adding the zsh-theme file extension to the set of supported file types.