### PR TITLE
added file type

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -22,6 +22,7 @@
   'install'
   'cygport'
   'bats'
+  'ebuild'
 ]
 'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|(?i:^\\s*#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-)'
 'patterns': [


### PR DESCRIPTION
ebuilds are without exception best displayed with shell highlighting.

Addresses issue #48