### PR TITLE
Adding support for core Unix commands and common package managers

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -1012,6 +1012,17 @@
         'name': 'support.function.builtin.shell'
       }
     ]
+  'support':
+    'patterns': [
+      {
+        'match': '(?<=^|\\s)(?::|\\.)(?=\\s|;|&|$)'
+        'name': 'support.function.unix.shell'
+      }
+      {
+        'match': '(?<![-/])\\b(?:base32|base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|echo|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|sha1sum|sha224sum|sha256sum|sha384sum|sha512sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b(?![-/])'
+        'name': 'support.function.unix.shell'
+      }
+    ]
   'variable':
     'patterns': [
       {

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -1008,19 +1008,20 @@
         'name': 'support.function.builtin.shell'
       }
       {
-        'match': '(?<![-/])\\b(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)\\b(?![-/])'
+        'match': '(?<![-/./])\\b(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)\\b(?![-/=/])'
         'name': 'support.function.builtin.shell'
       }
-    ]
-  'support':
-    'patterns': [
       {
-        'match': '(?<=^|\\s)(?::|\\.)(?=\\s|;|&|$)'
-        'name': 'support.function.unix.shell'
+        'match': '(?<![-/./])\\b(?:base32|base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|echo|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|sha1sum|sha224sum|sha256sum|sha384sum|sha512sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b(?![-/=/])'
+        'name': 'support.function.coreutils.shell'
       }
       {
-        'match': '(?<![-/])\\b(?:base32|base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|echo|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|sha1sum|sha224sum|sha256sum|sha384sum|sha512sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b(?![-/])'
-        'name': 'support.function.unix.shell'
+        'match': '(?<![-/./])\\b(?:apm|apt|apt-get|apt-cache|apt-key|add-apt-repository|apt-add-repository|apt-config|apt-mark|bundle|dpkg|dpkg-architecture|dpkg-buildflags|dpkg-buildpackage|dpkg-checkbuilddeps|dpkg-deb|dpkg-distaddfile|dpkg-divert|dpkg-genchanges|dpkg-gencontrol|dpkg-gensymbols|dpkg-log-summary|dpkg-maintscript-helper|dpkg-mergechangelogs|dpkg-name|dpkg-parsechangelog|dpkg-query|dpkg-scanpackages|dpkg-scansources|dpkg-shlibdeps|dpkg-source|dpkg-split|dpkg-statoverride|dpkg-trigger|dpkg-vendor|dnf|ebuild|emerge|equo|gem|lein|makepkg|npm|pacman|pip|pip3|revdep-rebuild|rpmbuild|urpme|urpmi|yum|zypper)\\b(?![-/=/])'
+        'name': 'support.function.packages.shell'
+      }
+      {
+        'match': '(?<![-/./])\\b(?:awk|ed|grep|nano|sed|sudo|vi|vim)\\b(?![-/=/])'
+        'name': 'support.function.extras.shell'
       }
     ]
   'variable':

--- a/package.json
+++ b/package.json
@@ -1,21 +1,25 @@
 {
-  "name": "language-shellscript",
+  "name": "language-shellscript2",
   "version": "0.22.3",
+  "author": "GitHub, Inc.",
+  "contributor": "Brenton Horne <brentonhorne77@gmail.com>",
+  "readme": "./README.md",
   "description": "ShellScript language support in Atom",
   "engines": {
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-shellscript",
+  "homepage": "http://atom.io/language-shellscript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/atom/language-shellscript.git"
+    "url": "https://github.com/fusion809/language-shellscript.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/atom/language-shellscript/issues"
+    "url": "https://github.com/fusion809/language-shellscript/issues"
   },
   "devDependencies": {
-    "coffeelint": "^1.10.1"
+    "coffeelint": "^1.10.1",
+    "coffee-script": "^1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "language-shellscript2",
+  "name": "language-shellscript",
   "version": "0.22.3",
   "author": "GitHub, Inc.",
-  "contributor": "Brenton Horne <brentonhorne77@gmail.com>",
   "readme": "./README.md",
   "description": "ShellScript language support in Atom",
   "engines": {
@@ -12,11 +11,11 @@
   "homepage": "http://atom.io/language-shellscript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fusion809/language-shellscript.git"
+    "url": "https://github.com/atom/language-shellscript.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fusion809/language-shellscript/issues"
+    "url": "https://github.com/atom/language-shellscript/issues"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1",


### PR DESCRIPTION
Hi,

In this pull request I am adding support to this package for core Unix commands (e.g., `cp`, `dd` and `sudo`) and common package managers, while also making some minor amendments to the package.json's metadata. This involved adding some extra Less styles which are not supported by most themes. If it helps, here are some example values for these styles:

```less
.source.shell {
  .support.function.coreutils {
    color: rgb(150,255,150);
  }

  .support.function.extras {
    color: rgb(255,150,200);
  }

  .support.function.packages {
    color: rgb(255,220,120);
  }
}
```

Thanks for your time,
Brenton