### PR TITLE
Revise modeline/hashbang-matching patterns

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -25,7 +25,25 @@
   'bats'
   'ebuild'
 ]
-'firstLineMatch': '^#!.*\\b(bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)|(?i:^\\s*#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-)'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    (?:bash|zsh|sh|tcsh|ksh|dash|ash|csh|rc)
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      (?:shell-script|sh)
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s* set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      sh
+    (?=\\s|:|$)
+  )
+'''
 'patterns': [
   {
     'include': '#comment'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -238,3 +238,117 @@ describe "Shell script grammar", ->
           x=$(($x-1))
         done
       """
+
+  describe "firstLineMatch", ->
+    it "recognises interpreter directives", ->
+      valid = """
+        #!/bin/sh
+        #!/usr/sbin/env bash
+        #!/usr/bin/bash foo=bar/
+        #!/usr/sbin/ksh foo bar baz
+        #!/usr/bin/dash perl
+        #!/usr/bin/env bin/sh
+        #!/usr/bin/rc
+        #!/bin/env rc
+        #!/usr/bin/bash --script=usr/bin
+        #! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail bash
+        #!\t/usr/bin/env --foo=bar bash --quu=quux
+        #! /usr/bin/bash
+        #!/usr/bin/env bash
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        \x20#!/usr/sbin/bash
+        \t#!/usr/sbin/bash
+        #!/usr/bin/env-bash/node-env/
+        #!/usr/bin/env-bash
+        #! /usr/binbash
+        #! /usr/arc
+        #!\t/usr/bin/env --bash=bar
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Emacs modelines", ->
+      valid = """
+        #-*-shell-script-*-
+        #-*-mode:shell-script-*-
+        /* -*-sh-*- */
+        // -*- SHELL-SCRIPT -*-
+        /* -*- mode:shell-script -*- */
+        // -*- font:bar;mode:sh -*-
+        // -*- font:bar;mode:shell-script;foo:bar; -*-
+        // -*-font:mode;mode:SH-*-
+        // -*- foo:bar mode: sh bar:baz -*-
+        " -*-foo:bar;mode:sh;bar:foo-*- ";
+        " -*-font-mode:foo;mode:shell-script;foo-bar:quux-*-"
+        "-*-font:x;foo:bar; mode : sh;bar:foo;foooooo:baaaaar;fo:ba;-*-";
+        "-*- font:x;foo : bar ; mode : sH ; bar : foo ; foooooo:baaaaar;fo:ba-*-";
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        /* --*sh-*- */
+        /* -*-- sh -*-
+        /* -*- -- sh -*-
+        /* -*- shell-scripts -;- -*-
+        // -*- SSSSSSSSSH -*-
+        // -*- SH; -*-
+        // -*- sh-stuff -*-
+        /* -*- model:sh -*-
+        /* -*- indent-mode:sh -*-
+        // -*- font:mode;SH -*-
+        // -*- mode: -*- SH
+        // -*- mode: secret-sh -*-
+        // -*-font:mode;mode:sh--*-
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Vim modelines", ->
+      valid = """
+        vim: se filetype=sh:
+        # vim: se ft=sh:
+        # vim: set ft=sh:
+        # vim: set filetype=sh:
+        # vim: ft=sh
+        # vim: syntax=sH
+        # vim: se syntax=SH:
+        # ex: syntax=SH
+        # vim:ft=sh
+        # vim600: ft=sh
+        # vim>600: set ft=sh:
+        # vi:noai:sw=3 ts=6 ft=sh
+        # vi::::::::::noai:::::::::::: ft=sh
+        # vim:ts=4:sts=4:sw=4:noexpandtab:ft=sh
+        # vi:: noai : : : : sw   =3 ts   =6 ft  =sh
+        # vim: ts=4: pi sts=4: ft=sh: noexpandtab: sw=4:
+        # vim: ts=4 sts=4: ft=sh noexpandtab:
+        # vim:noexpandtab sts=4 ft=sh ts=4
+        # vim:noexpandtab:ft=sh
+        # vim:ts=4:sts=4 ft=sh:noexpandtab:\x20
+        # vim:noexpandtab titlestring=hi\|there\\\\ ft=sh ts=4
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        ex: se filetype=sh:
+        _vi: se filetype=sh:
+         vi: se filetype=sh
+        # vim set ft=ssh
+        # vim: soft=sh
+        # vim: hairy-syntax=sh:
+        # vim set ft=sh:
+        # vim: setft=sh:
+        # vim: se ft=sh backupdir=tmp
+        # vim: set ft=sh set cmdheight=1
+        # vim:noexpandtab sts:4 ft:sh ts:4
+        # vim:noexpandtab titlestring=hi\\|there\\ ft=sh ts=4
+        # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=sh ts=4
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()


### PR DESCRIPTION
This PR adds the battle-hardened modeline patterns tested at [Linguist](https://github.com/github/linguist/pull/3237), and also addresses a boundary-matching issue that causes the grammar to be falsely activated by `#!/bin/rubbi-sh`.