### PR TITLE
Fix greedy variable match in for loops

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -777,7 +777,7 @@
         ]
       }
       {
-        'begin': '\\b(for)\\b\\s+(.+)\\s+\\b(in)\\b'
+        'begin': '\\b(for)\\b\\s+(.+?)\\s+\\b(in)\\b'
         'beginCaptures':
           '1':
             'name': 'keyword.control.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -78,6 +78,12 @@ describe "Shell script grammar", ->
     expect(tokens[18]).toEqual value: ' something ', scopes: ['source.shell', 'meta.scope.for-in-loop.shell']
     expect(tokens[19]).toEqual value: 'done', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
 
+    {tokens} = grammar.tokenizeLine('for variable in something do # in')
+
+    expect(tokens[4]).toEqual value: 'in', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
+    expect(tokens[8]).toEqual value: '#', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'comment.line.number-sign.shell', 'punctuation.definition.comment.shell']
+    expect(tokens[9]).toEqual value: ' in', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'comment.line.number-sign.shell']
+
   it "doesn't tokenize keywords when they're part of a phrase", ->
     {tokens} = grammar.tokenizeLine('grep --ignore-case "something"')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR makes a greedy variable capture in a for...in loop lazy to avoid scenarios like the following: `for variable in something do # hey look a comment with in`.  Prior to this change, the variable matching would keep matching until the last `in`, even if it was in a comment or totally irrelevant.

### Alternate Designs

N/A

### Benefits

See above.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #51