### PR TITLE
Minor cleanups to grammar source

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -613,7 +613,7 @@
   'herestring':
     'patterns': [
       {
-        'begin': '(<<<)\s*((\'))'
+        'begin': '(<<<)\\s*((\'))'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.herestring.shell'
@@ -631,7 +631,7 @@
         'contentName': 'string.quoted.single.shell'
       }
       {
-        'begin': '(<<<)\s*(("))'
+        'begin': '(<<<)\\s*(("))'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.herestring.shell'

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -1060,7 +1060,7 @@
         'name': 'variable.other.bracket.shell'
         'patterns': [
           {
-            'match': '!|:[-=?]?|\\*|@|#{1,2}|%{1,2}|/'
+            'match': '!|:[-=?]?|\\*|@|\#\{1,2}|%{1,2}|/' # #{ is escaped to prevent coffeelint complaining about interpolation
             'name': 'keyword.operator.expansion.shell'
           }
           {

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -103,11 +103,14 @@
         'name': 'meta.scope.case-clause.shell'
         'patterns': [
           {
-            'begin': '(\\(|(?=\\S))'
-            'captures':
+            'begin': '\\(|(?=\\S)'
+            'beginCaptures':
               '0':
                 'name': 'punctuation.definition.case-pattern.shell'
             'end': '\\)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.case-pattern.shell'
             'name': 'meta.scope.case-pattern.shell'
             'patterns': [
               {
@@ -168,11 +171,14 @@
   'compound-command':
     'patterns': [
       {
-        'begin': '(\\[{1,2})'
-        'captures':
-          '1':
+        'begin': '\\[{1,2}'
+        'beginCaptures':
+          '0':
             'name': 'punctuation.definition.logical-expression.shell'
-        'end': '(\\]{1,2})'
+        'end': '\\]{1,2}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.logical-expression.shell'
         'name': 'meta.scope.logical-expression.shell'
         'patterns': [
           {
@@ -184,11 +190,11 @@
         ]
       }
       {
-        'begin': '(\\({2})'
+        'begin': '\\({2}'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.shell'
-        'end': '(\\){2})'
+        'end': '\\){2}'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.shell'
@@ -200,11 +206,14 @@
         ]
       }
       {
-        'begin': '(\\()'
-        'captures':
-          '1':
+        'begin': '\\('
+        'beginCaptures':
+          '0':
             'name': 'punctuation.definition.subshell.shell'
-        'end': '(\\))'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.subshell.shell'
         'name': 'meta.scope.subshell.shell'
         'patterns': [
           {
@@ -213,11 +222,14 @@
         ]
       }
       {
-        'begin': '(?<=\\s|^)(\\{)(?=\\s|$)'
-        'captures':
+        'begin': '(?<=\\s|^){(?=\\s|$)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.group.shell'
+        'end': '(?<=^|;)\\s*(})'
+        'endCaptures':
           '1':
             'name': 'punctuation.definition.group.shell'
-        'end': '(?<=^|;)\\s*(\\})'
         'name': 'meta.scope.group.shell'
         'patterns': [
           {
@@ -276,15 +288,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.ruby.embedded.shell'
         'end': '^\\t*(RUBY)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.ruby.shell'
+        'contentName': 'source.ruby.embedded.shell'
         'patterns': [
           {
             'include': 'source.ruby'
@@ -298,15 +307,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.ruby.embedded.shell'
         'end': '^(RUBY)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.ruby.shell'
+        'contentName': 'source.ruby.embedded.shell'
         'patterns': [
           {
             'include': 'source.ruby'
@@ -320,15 +326,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.python.embedded.shell'
         'end': '^\\t*(PYTHON)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.python.shell'
+        'contentName': 'source.python.embedded.shell'
         'patterns': [
           {
             'include': 'source.python'
@@ -342,15 +345,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.python.embedded.shell'
         'end': '^(PYTHON)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.python.shell'
+        'contentName': 'source.python.embedded.shell'
         'patterns': [
           {
             'include': 'source.python'
@@ -364,15 +364,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.applescript.embedded.shell'
         'end': '^\\t*(APPLESCRIPT)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.applescript.shell'
+        'contentName': 'source.applescript.embedded.shell'
         'patterns': [
           {
             'include': 'source.applescript'
@@ -386,15 +383,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.applescript.embedded.shell'
         'end': '^(APPLESCRIPT)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.applescript.shell'
+        'contentName': 'source.applescript.embedded.shell'
         'patterns': [
           {
             'include': 'source.applescript'
@@ -408,15 +402,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.embedded.shell'
         'end': '^\\t*(HTML)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.html.shell'
+        'contentName': 'text.html.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.basic'
@@ -430,15 +421,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.embedded.shell'
         'end': '^(HTML)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.html.shell'
+        'contentName': 'text.html.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.basic'
@@ -452,15 +440,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.markdown.embedded.shell'
         'end': '^\\t*(MARKDOWN)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.markdown.shell'
+        'contentName': 'text.html.markdown.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.markdown'
@@ -474,15 +459,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.markdown.embedded.shell'
         'end': '^(MARKDOWN)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.markdown.shell'
+        'contentName': 'text.html.markdown.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.markdown'
@@ -496,15 +478,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.textile.embedded.shell'
         'end': '^\\t*(TEXTILE)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.no-indent.textile.shell'
+        'contentName': 'text.html.textile.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.textile'
@@ -518,15 +497,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'text.html.textile.embedded.shell'
         'end': '^(TEXTILE)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.textile.shell'
+        'contentName': 'text.html.textile.embedded.shell'
         'patterns': [
           {
             'include': 'text.html.textile'
@@ -540,14 +516,11 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.shell.embedded.shell'
         'end': '^\\t*(\\3)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
+        'contentName': 'source.shell.embedded.shell'
         'name': 'string.unquoted.heredoc.no-indent.shell.shell'
         'patterns': [
           {
@@ -562,15 +535,12 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
-        'contentName': 'source.shell.embedded.shell'
         'end': '^(\\3)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.shell.shell'
+        'contentName': 'source.shell.embedded.shell'
         'patterns': [
           {
             'include': 'source.shell'
@@ -584,9 +554,6 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
         'end': '^\\t*(\\3)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
@@ -600,9 +567,6 @@
             'name': 'keyword.operator.heredoc.shell'
           '3':
             'name': 'keyword.control.heredoc-token.shell'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.shell'
         'end': '^(\\3)(?=\\s|;|&|$)'
         'endCaptures':
           '1':
@@ -765,10 +729,13 @@
     'patterns': [
       {
         'begin': '(?<=^|;|&|\\s)(for)\\s+(?=\\({2})'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'keyword.control.shell'
-        'end': '(?<=^|;|&|\\s)(done)(?=\\s|;|&|$)'
+        'end': '(?<=^|;|&|\\s)done(?=\\s|;|&|$)'
+        'endCaptures':
+          '0':
+            'name': 'keyword.control.shell'
         'name': 'meta.scope.for-loop.shell'
         'patterns': [
           {
@@ -803,10 +770,13 @@
       }
       {
         'begin': '(?<=^|;|&|\\s)(while|until)(?=\\s|;|&|$)'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'keyword.control.shell'
-        'end': '(?<=^|;|&|\\s)(done)(?=\\s|;|&|$)'
+        'end': '(?<=^|;|&|\\s)done(?=\\s|;|&|$)'
+        'endCaptures':
+          '0':
+            'name': 'keyword.control.shell'
         'name': 'meta.scope.while-loop.shell'
         'patterns': [
           {
@@ -833,19 +803,22 @@
         ]
       }
       {
-        'begin': '(?<=^|;|&|\\s)(case)(?=\\s|;|&|$)'
-        'captures':
-          '1':
+        'begin': '(?<=^|;|&|\\s)case(?=\\s|;|&|$)'
+        'beginCaptures':
+          '0':
             'name': 'keyword.control.shell'
-        'end': '(?<=^|;|&|\\s)(esac)(?=\\s|;|&|$)'
+        'end': '(?<=^|;|&|\\s)esac(?=\\s|;|&|$)'
+        'endCaptures':
+          '0':
+            'name': 'keyword.control.shell'
         'name': 'meta.scope.case-block.shell'
         'patterns': [
           {
-            'begin': '(?<=^|;|&|\\s)(in)(?=\\s|;|&|$)'
+            'begin': '(?<=^|;|&|\\s)in(?=\\s|;|&|$)'
             'beginCaptures':
-              '1':
+              '0':
                 'name': 'keyword.control.shell'
-            'end': '(?<=^|;|&|\\s)(?=(?:esac)(?:\\s|;|&|$))'
+            'end': '(?<=^|;|&|\\s)(?=esac(\\s|;|&|$))'
             'name': 'meta.scope.case-body.shell'
             'patterns': [
               {
@@ -865,11 +838,14 @@
         ]
       }
       {
-        'begin': '(?<=^|;|&|\\s)(if)(?=\\s|;|&|$)'
-        'captures':
-          '1':
+        'begin': '(?<=^|;|&|\\s)if(?=\\s|;|&|$)'
+        'beginCaptures':
+          '0':
             'name': 'keyword.control.shell'
-        'end': '(?<=^|;|&|\\s)(fi)(?=\\s|;|&|$)'
+        'end': '(?<=^|;|&|\\s)fi(?=\\s|;|&|$)'
+        'endCaptures':
+          '0':
+            'name': 'keyword.control.shell'
         'name': 'meta.scope.if-block.shell'
         'patterns': [
           {
@@ -921,9 +897,9 @@
             'name': 'keyword.operator.extglob.shell'
           '2':
             'name': 'punctuation.definition.extglob.shell'
-        'end': '(\\))'
+        'end': '\\)'
         'endCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.extglob.shell'
         'name': 'meta.structure.extglob.shell'
         'patterns': [
@@ -963,7 +939,7 @@
         ]
       }
       {
-        'comment': 'valid: &>word >&word >word [n]>&[n] [n]<word [n]>word [n]>>word [n]<&word (last one is duplicate)'
+        # valid: &>word >&word >word [n]>&[n] [n]<word [n]>word [n]>>word [n]<&word (last one is duplicate)
         'match': '&>|\\d*>&\\d*|\\d*(>>|>|<)|\\d*<&|\\d*<>'
         'name': 'keyword.operator.redirect.shell'
       }
@@ -1073,11 +1049,14 @@
         'name': 'variable.other.positional.shell'
       }
       {
-        'begin': '\\$\\{'
-        'captures':
+        'begin': '\\${'
+        'beginCaptures':
           '0':
             'name': 'punctuation.definition.variable.shell'
-        'end': '\\}'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.variable.shell'
         'name': 'variable.other.bracket.shell'
         'patterns': [
           {

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -22,7 +22,6 @@ describe "Shell script grammar", ->
 
   it "tokenizes strings inside variable constructs", ->
     {tokens} = grammar.tokenizeLine("${'root'}")
-
     expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
     expect(tokens[1]).toEqual value: "'", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
     expect(tokens[2]).toEqual value: "root", scopes: ['source.shell', 'variable.other.bracket.shell', 'string.quoted.single.shell']
@@ -31,7 +30,6 @@ describe "Shell script grammar", ->
 
   it "tokenizes if correctly when it's a parameter", ->
     {tokens} = grammar.tokenizeLine('dd if=/dev/random of=/dev/null')
-
     expect(tokens[0]).toEqual value: 'dd if=/dev/random of=/dev/null', scopes: ['source.shell']
 
   it "tokenizes if as a keyword", ->
@@ -41,7 +39,6 @@ describe "Shell script grammar", ->
 
     for openingBracket, closingBracket of brackets
       {tokens} = grammar.tokenizeLine('if ' + openingBracket + ' -f /var/log/messages ' + closingBracket)
-
       expect(tokens[0]).toEqual value: 'if', scopes: ['source.shell', 'meta.scope.if-block.shell', 'keyword.control.shell']
       expect(tokens[2]).toEqual value: openingBracket, scopes: ['source.shell', 'meta.scope.if-block.shell', 'meta.scope.logical-expression.shell', 'punctuation.definition.logical-expression.shell']
       expect(tokens[4]).toEqual value: '-f', scopes: ['source.shell', 'meta.scope.if-block.shell', 'meta.scope.logical-expression.shell', 'keyword.operator.logical.shell']
@@ -50,7 +47,6 @@ describe "Shell script grammar", ->
 
   it "tokenizes for...in loops", ->
     {tokens} = grammar.tokenizeLine('for variable in file do do-something-done done')
-
     expect(tokens[0]).toEqual value: 'for', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
     expect(tokens[2]).toEqual value: 'variable', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'variable.other.loop.shell']
     expect(tokens[4]).toEqual value: 'in', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
@@ -60,7 +56,6 @@ describe "Shell script grammar", ->
     expect(tokens[8]).toEqual value: 'done', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
 
     {tokens} = grammar.tokenizeLine('for "variable" in "${list[@]}" do something done')
-
     expect(tokens[0]).toEqual value: 'for', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'variable.other.loop.shell', 'string.quoted.double.shell', 'punctuation.definition.string.begin.shell']
     expect(tokens[3]).toEqual value: 'variable', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'variable.other.loop.shell', 'string.quoted.double.shell']
@@ -79,14 +74,12 @@ describe "Shell script grammar", ->
     expect(tokens[19]).toEqual value: 'done', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
 
     {tokens} = grammar.tokenizeLine('for variable in something do # in')
-
     expect(tokens[4]).toEqual value: 'in', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'keyword.control.shell']
     expect(tokens[8]).toEqual value: '#', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'comment.line.number-sign.shell', 'punctuation.definition.comment.shell']
     expect(tokens[9]).toEqual value: ' in', scopes: ['source.shell', 'meta.scope.for-in-loop.shell', 'comment.line.number-sign.shell']
 
   it "doesn't tokenize keywords when they're part of a phrase", ->
     {tokens} = grammar.tokenizeLine('grep --ignore-case "something"')
-
     expect(tokens[0]).toEqual value: 'grep --ignore-case ', scopes: ['source.shell']
     expect(tokens[1]).toEqual value: '"', scopes: ['source.shell', 'string.quoted.double.shell', 'punctuation.definition.string.begin.shell']
 
@@ -105,20 +98,15 @@ describe "Shell script grammar", ->
 
     for string in strings
       {tokens} = grammar.tokenizeLine(string)
-
       expect(tokens[0]).toEqual value: string, scopes: ['source.shell']
 
     {tokens} = grammar.tokenizeLine('this/function ()')
-
     expect(tokens[0]).toEqual value: 'this/function', scopes: ['source.shell', 'meta.function.shell', 'entity.name.function.shell']
     expect(tokens[2]).toEqual value: '()', scopes: ['source.shell', 'meta.function.shell', 'punctuation.definition.arguments.shell']
 
     {tokens} = grammar.tokenizeLine('and,for (( this ))')
-
     expect(tokens[0]).toEqual value: 'and,for ', scopes: ['source.shell']
     expect(tokens[1]).toEqual value: '((', scopes: ['source.shell', 'string.other.math.shell', 'punctuation.definition.string.begin.shell']
-
-    {tokens} = grammar.tokenizeLine('in🚀case of stuff')
 
   it "tokenizes herestrings", ->
     delimsByScope =
@@ -130,7 +118,6 @@ describe "Shell script grammar", ->
       $cmd <<<#{delim}
       lorem ipsum#{delim}
       """
-
       expect(tokens[0][0]).toEqual value: '$', scopes: ['source.shell', 'variable.other.normal.shell', 'punctuation.definition.variable.shell']
       expect(tokens[0][1]).toEqual value: 'cmd', scopes: ['source.shell', 'variable.other.normal.shell']
       expect(tokens[0][3]).toEqual value: '<<<', scopes: ['source.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
@@ -143,7 +130,6 @@ describe "Shell script grammar", ->
       $cmd <<< #{delim}
       lorem ipsum#{delim}
       """
-
       expect(tokens[0][0]).toEqual value: '$', scopes: ['source.shell', 'variable.other.normal.shell', 'punctuation.definition.variable.shell']
       expect(tokens[0][1]).toEqual value: 'cmd', scopes: ['source.shell', 'variable.other.normal.shell']
       expect(tokens[0][3]).toEqual value: '<<<', scopes: ['source.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
@@ -165,7 +151,6 @@ describe "Shell script grammar", ->
         stuff
         #{delim}
       """
-
       expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
       expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
       expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
@@ -176,7 +161,6 @@ describe "Shell script grammar", ->
         stuff
         #{delim}
       """
-
       expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
       expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
       expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
@@ -193,7 +177,6 @@ describe "Shell script grammar", ->
         stuff
         #{delim}
       """
-
       expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.operator.heredoc.shell']
       expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
       expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
@@ -201,25 +184,21 @@ describe "Shell script grammar", ->
 
   it "tokenizes shebangs", ->
     {tokens} = grammar.tokenizeLine('#!/bin/sh')
-
     expect(tokens[0]).toEqual value: '#!', scopes: ['source.shell', 'comment.line.number-sign.shebang.shell', 'punctuation.definition.comment.shebang.shell']
     expect(tokens[1]).toEqual value: '/bin/sh', scopes: ['source.shell', 'comment.line.number-sign.shebang.shell']
 
   it "tokenizes comments", ->
     {tokens} = grammar.tokenizeLine('#comment')
-
     expect(tokens[0]).toEqual value: '#', scopes: ['source.shell', 'comment.line.number-sign.shell', 'punctuation.definition.comment.shell']
     expect(tokens[1]).toEqual value: 'comment', scopes: ['source.shell', 'comment.line.number-sign.shell']
 
   it "tokenizes comments in interpolated strings", ->
     {tokens} = grammar.tokenizeLine('`#comment`')
-
     expect(tokens[1]).toEqual value: '#', scopes: ['source.shell', 'string.interpolated.backtick.shell', 'comment.line.number-sign.shell', 'punctuation.definition.comment.shell']
     expect(tokens[3]).toEqual value: '`', scopes: ['source.shell', 'string.interpolated.backtick.shell', 'punctuation.definition.string.end.shell']
 
   it "tokenizes nested variable expansions", ->
     {tokens} = grammar.tokenizeLine('${${C}}')
-
     expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
     expect(tokens[1]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']
     expect(tokens[2]).toEqual value: 'C', scopes: ['source.shell', 'variable.other.bracket.shell', 'variable.other.bracket.shell']
@@ -228,7 +207,6 @@ describe "Shell script grammar", ->
 
   it "tokenizes case blocks", ->
     {tokens} = grammar.tokenizeLine('case word in esac);; esac')
-
     expect(tokens[0]).toEqual value: 'case', scopes: ['source.shell', 'meta.scope.case-block.shell', 'keyword.control.shell']
     expect(tokens[1]).toEqual value: ' word ', scopes: ['source.shell', 'meta.scope.case-block.shell']
     expect(tokens[2]).toEqual value: 'in', scopes: ['source.shell', 'meta.scope.case-block.shell', 'meta.scope.case-body.shell', 'keyword.control.shell']

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -138,6 +138,20 @@ describe "Shell script grammar", ->
       expect(tokens[1][0]).toEqual value: 'lorem ipsum', scopes: ['source.shell', 'meta.herestring.shell', scope]
       expect(tokens[1][1]).toEqual value: delim, scopes: ['source.shell', 'meta.herestring.shell', scope, 'punctuation.definition.string.end.shell']
 
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines """
+      $cmd <<< #{delim}
+      lorem ipsum#{delim}
+      """
+
+      expect(tokens[0][0]).toEqual value: '$', scopes: ['source.shell', 'variable.other.normal.shell', 'punctuation.definition.variable.shell']
+      expect(tokens[0][1]).toEqual value: 'cmd', scopes: ['source.shell', 'variable.other.normal.shell']
+      expect(tokens[0][3]).toEqual value: '<<<', scopes: ['source.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
+      expect(tokens[0][4]).toEqual value: ' ', scopes: ['source.shell', 'meta.herestring.shell']
+      expect(tokens[0][5]).toEqual value: delim, scopes: ['source.shell', 'meta.herestring.shell', scope, 'punctuation.definition.string.begin.shell']
+      expect(tokens[1][0]).toEqual value: 'lorem ipsum', scopes: ['source.shell', 'meta.herestring.shell', scope]
+      expect(tokens[1][1]).toEqual value: delim, scopes: ['source.shell', 'meta.herestring.shell', scope, 'punctuation.definition.string.end.shell']
+
   it "tokenizes heredocs", ->
     delimsByScope =
       "ruby": "RUBY"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Cosmetic cleanups for the most part.
* Explicitly use `beginCaptures` and `endCaptures` when dealing with `begin` and `end` matches rather than using a `capture` to handle both.
* Remove captures that weren't doing anything.  I plan to return to heredocs and herestrings in the future to give them a proper makeover.
* Move `contentName` to below `name` where both exist.
* Unescape `{` and `}`.
* Remove unnecessary capturing groups.
* Fix herestrings not properly escaping spaces, leading `<<<ssssssssss'hi!'` to be tokenized as a valid herestring.  While funny, not really that useful...

### Alternate Designs

N/A

### Benefits

See above.

### Possible Drawbacks

None.

### Applicable Issues

None.
