### PR TITLE
Stop suggesting function for fi

### DIFF
--- a/snippets/language-shellscript.cson
+++ b/snippets/language-shellscript.cson
@@ -20,6 +20,9 @@
   'elif …':
     'prefix': 'elif'
     'body': 'elif ${2:[[ ${1:condition} ]]}; then\n\t${0:#statements}'
+  'fi':
+    'prefix': 'fi'
+    'body': 'fi'
   'for … done':
     'prefix': 'for'
     'body': 'for (( i = 0; i < ${1:10}; i++ )); do\n\t${0:#statements}\ndone'


### PR DESCRIPTION
### Description of the Change

This fixes a very annoying behavior where Atom suggests me function (because it contains f and i) when I type fi to close an if statement.

This fix adds a `fi` snippet that just does fi so that users can type fi to get fi and type more letters of function to get function.

### Alternate Designs

remove the function snippet altogether

### Benefits

usability. I never use the function snippet but I type fi about 100 times per day. Each time I need to be careful not to press ENTER but ESCAPE to abort the snippet suggestion.

### Possible Drawbacks

none that I can think of.

### Applicable Issues

I did not create an issue because the fix is so obvious that I thought to just contribute it :-)