### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -774,7 +774,7 @@
         'name': 'keyword.operator.arithmetic.shell'
       }
       {
-        'match': '0[xX]\\h+'
+        'match': '0[xX][0-9A-Fa-f]+'
         'name': 'constant.numeric.hex.shell'
       }
       {


### PR DESCRIPTION
### Description of the Change

Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.

### Alternate Designs

None were considered.

### Benefits

Makes the grammar PCRE-compatible, so that it can be used on github.com.

### Possible Drawbacks

I don't have any way to check these PCRE vs. Oniguruma discrepancies at the moment. I'm working on a new test at the Linguist-level to check for all known discrepancies.