### PR TITLE
Allow spaces before heredoc identifier

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -282,7 +282,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(<<)-("|\'|)(RUBY)\\2'
+        'begin': '(<<)-("|\'|)\\s*(RUBY)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -301,7 +301,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(RUBY)\\2'
+        'begin': '(<<)("|\'|)\\s*(RUBY)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -320,7 +320,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(PYTHON)\\2'
+        'begin': '(<<)-("|\'|)\\s*(PYTHON)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -339,7 +339,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(PYTHON)\\2'
+        'begin': '(<<)("|\'|)\\s*(PYTHON)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -358,7 +358,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(APPLESCRIPT)\\2'
+        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -377,7 +377,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(APPLESCRIPT)\\2'
+        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -396,7 +396,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(HTML)\\2'
+        'begin': '(<<)-("|\'|)\\s*(HTML)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -415,7 +415,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(HTML)\\2'
+        'begin': '(<<)("|\'|)\\s*(HTML)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -434,7 +434,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(MARKDOWN)\\2'
+        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(MARKDOWN)\\2'
+        'begin': '(<<)("|\'|)\\s*(MARKDOWN)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -472,7 +472,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(TEXTILE)\\2'
+        'begin': '(<<)-("|\'|)\\s*(TEXTILE)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -491,7 +491,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(TEXTILE)\\2'
+        'begin': '(<<)("|\'|)\\s*(TEXTILE)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -510,7 +510,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)(SHELL)\\2'
+        'begin': '(<<)-("|\'|)\\s*(SHELL)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -529,7 +529,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)(SHELL)\\2'
+        'begin': '(<<)("|\'|)\\s*(SHELL)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\\\?(\\w+)\\2'
+        'begin': '(<<)-("|\'|)\\s*\\\\?(\\w+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)("|\'|)\\\\?(\\w+)\\2'
+        'begin': '(<<)("|\'|)\\s*\\\\?(\\w+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -157,11 +157,33 @@ describe "Shell script grammar", ->
       expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
 
       tokens = grammar.tokenizeLines """
+        << #{delim}
+        stuff
+        #{delim}
+      """
+      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell']
+      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+      tokens = grammar.tokenizeLines """
         <<-#{delim}
         stuff
         #{delim}
       """
       expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+      tokens = grammar.tokenizeLines """
+        <<- #{delim}
+        stuff
+        #{delim}
+      """
+      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+      expect(tokens[0][1]).toEqual value: '- ', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell']
       expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
       expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
       expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']


### PR DESCRIPTION
Spaces are allowed before the heredoc identifier, so recognize them.

Fixes atom/atom#15397