### PR TITLE
Properly delimit heredoc identifiers

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -73,10 +73,10 @@
     'include': '#interpolation'
   }
   {
-    'include': '#heredoc'
+    'include': '#herestring'
   }
   {
-    'include': '#herestring'
+    'include': '#heredoc'
   }
   {
     'include': '#redirection'
@@ -282,7 +282,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(<<)-("|\'|)\\s*(RUBY)\\2'
+        'begin': '(<<)-("|\'|)\\s*(RUBY)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -301,7 +301,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(RUBY)\\2'
+        'begin': '(<<)("|\'|)\\s*(RUBY)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -320,7 +320,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(PYTHON)\\2'
+        'begin': '(<<)-("|\'|)\\s*(PYTHON)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -339,7 +339,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(PYTHON)\\2'
+        'begin': '(<<)("|\'|)\\s*(PYTHON)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -358,7 +358,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)\\2'
+        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -377,7 +377,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)\\2'
+        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -396,7 +396,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(HTML)\\2'
+        'begin': '(<<)-("|\'|)\\s*(HTML)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -415,7 +415,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(HTML)\\2'
+        'begin': '(<<)("|\'|)\\s*(HTML)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -434,7 +434,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)\\2'
+        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(MARKDOWN)\\2'
+        'begin': '(<<)("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -472,7 +472,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(TEXTILE)\\2'
+        'begin': '(<<)-("|\'|)\\s*(TEXTILE)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -491,7 +491,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(TEXTILE)\\2'
+        'begin': '(<<)("|\'|)\\s*(TEXTILE)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -510,7 +510,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(SHELL)\\2'
+        'begin': '(<<)-("|\'|)\\s*(SHELL)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -529,7 +529,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(SHELL)\\2'
+        'begin': '(<<)("|\'|)\\s*(SHELL)(?=\\s|;|&|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*\\\\?(\\w+)\\2'
+        'begin': '(<<)-("|\'|)\\s*\\\\?([^;&\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)("|\'|)\\s*\\\\?(\\w+)\\2'
+        'begin': '(<<)("|\'|)\\s*\\\\?([^;&\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'

--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -73,10 +73,10 @@
     'include': '#interpolation'
   }
   {
-    'include': '#herestring'
+    'include': '#heredoc'
   }
   {
-    'include': '#heredoc'
+    'include': '#herestring'
   }
   {
     'include': '#redirection'
@@ -282,7 +282,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(<<)-("|\'|)\\s*(RUBY)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -301,7 +301,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(RUBY)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -320,7 +320,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(PYTHON)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -339,7 +339,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(PYTHON)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -358,7 +358,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -377,7 +377,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -396,7 +396,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(HTML)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -415,7 +415,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(HTML)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -434,7 +434,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -472,7 +472,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(TEXTILE)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -491,7 +491,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(TEXTILE)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -510,7 +510,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(SHELL)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)-("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -529,7 +529,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(SHELL)(?=\\s|;|&|"|\')\\2'
+        'begin': '(<<)("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*\\\\?([^;&\\s]+)\\2'
+        'begin': '(<<)-("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)("|\'|)\\s*\\\\?([^;&\\s]+)\\2'
+        'begin': '(<<)("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -191,9 +191,10 @@ describe "Shell script grammar", ->
     delims = [
       "RANDOMTHING"
       "RUBY@1.8"
+      "END-INPUT"
     ]
 
-    for delim of delims
+    for delim in delims
       tokens = grammar.tokenizeLines """
         <<#{delim}
         stuff


### PR DESCRIPTION
Two issues have been fixed with this PR.  The first one is that for language-specific heredocs, there was no boundary checking being performed.  Which meant that `<<SHELLOILCOMPANY` caused the heredoc to be tokenized as Shell.  The second one was that generic heredocs were _too_ strict with the valid identifier regex, only allowing word characters.  It now uses a negative character class against `;`, `&`, `<`, and whitespace.

The spec which was supposed to catch the first issue was broken and is fixed in this PR.

Fixes #71