### PR TITLE
Tokenize unquoted herestrings properly

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -618,7 +618,12 @@
             'name': 'keyword.operator.herestring.shell'
           '2':
             'name': 'string.unquoted.herestring.shell'
-        'match': '(<<<)(([^\\s\\\\]|\\\\.)+)'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+        'match': '(<<<)\\s*(([^\\s\\\\]|\\\\.)+)'
         'name': 'meta.herestring.shell'
       }
     ]
@@ -940,7 +945,7 @@
       }
       {
         # valid: &>word >&word >word [n]>&[n] [n]<word [n]>word [n]>>word [n]<&word (last one is duplicate)
-        'match': '&>|\\d*>&\\d*|\\d*(>>|>|<)|\\d*<&|\\d*<>'
+        'match': '(?<![<>])(&>|\\d*>&\\d*|\\d*(>>|>|<)|\\d*<&|\\d*<>)(?![<>])'
         'name': 'keyword.operator.redirect.shell'
       }
     ]

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -138,6 +138,18 @@ describe "Shell script grammar", ->
       expect(tokens[1][0]).toEqual value: 'lorem ipsum', scopes: ['source.shell', 'meta.herestring.shell', scope]
       expect(tokens[1][1]).toEqual value: delim, scopes: ['source.shell', 'meta.herestring.shell', scope, 'punctuation.definition.string.end.shell']
 
+    {tokens} = grammar.tokenizeLine '$cmd = something <<< $COUNTRIES'
+    expect(tokens[3]).toEqual value: '<<<', scopes: ['source.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.shell', 'meta.herestring.shell']
+    expect(tokens[5]).toEqual value: '$', scopes: ['source.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell', 'variable.other.normal.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[6]).toEqual value: 'COUNTRIES', scopes: ['source.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell', 'variable.other.normal.shell']
+
+    {tokens} = grammar.tokenizeLine '$cmd = something <<< TEST 1 2'
+    expect(tokens[3]).toEqual value: '<<<', scopes: ['source.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.shell', 'meta.herestring.shell']
+    expect(tokens[5]).toEqual value: 'TEST', scopes: ['source.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell']
+    expect(tokens[6]).toEqual value: ' 1 2', scopes: ['source.shell']
+
   it "tokenizes heredocs", ->
     delimsByScope =
       "ruby": "RUBY"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There can be spaces between the herestring token and identifier.

### Alternate Designs

N/A

### Benefits

Proper herestring highlighting.

### Possible Drawbacks

N/A

### Applicable Issues

Fixes #82