### PR TITLE
End herestrings when parentheses are reached

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -623,7 +623,7 @@
                 'include': '$self'
               }
             ]
-        'match': '(<<<)\\s*(([^\\s\\\\]|\\\\.)+)'
+        'match': '(<<<)\\s*(([^\\s)\\\\]|\\\\.)+)'
         'name': 'meta.herestring.shell'
       }
     ]

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -150,6 +150,12 @@ describe "Shell script grammar", ->
     expect(tokens[5]).toEqual value: 'TEST', scopes: ['source.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell']
     expect(tokens[6]).toEqual value: ' 1 2', scopes: ['source.shell']
 
+    {tokens} = grammar.tokenizeLine '$cmd = "$(3 / x <<< $WORD)"'
+    expect(tokens[6]).toEqual value: '<<<', scopes: ['source.shell', 'string.quoted.double.shell', 'string.interpolated.dollar.shell', 'meta.herestring.shell', 'keyword.operator.herestring.shell']
+    expect(tokens[8]).toEqual value: '$', scopes: ['source.shell', 'string.quoted.double.shell', 'string.interpolated.dollar.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell', 'variable.other.normal.shell', 'punctuation.definition.variable.shell']
+    expect(tokens[9]).toEqual value: 'WORD', scopes: ['source.shell', 'string.quoted.double.shell', 'string.interpolated.dollar.shell', 'meta.herestring.shell', 'string.unquoted.herestring.shell', 'variable.other.normal.shell']
+    expect(tokens[10]).toEqual value: ')', scopes: ['source.shell', 'string.quoted.double.shell', 'string.interpolated.dollar.shell', 'punctuation.definition.string.end.shell']
+
   it "tokenizes heredocs", ->
     delimsByScope =
       "ruby": "RUBY"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`)` cannot be a part of a `word`, therefore do not treat it as one in herestrings.

### Alternate Designs

None.

### Benefits

Herestrings that are ended by parentheses will be tokenized correctly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #90