### PR TITLE
Add tree-sitter Bash grammar

### DIFF
--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -2,6 +2,7 @@ id: 'bash'
 name: 'Bash'
 type: 'tree-sitter'
 parser: 'tree-sitter-bash'
+legacyScopeName: 'source.shell'
 
 fileTypes: [
   'sh'

--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -64,8 +64,10 @@ scopes:
   'raw_string': 'string'
   'heredoc': 'string'
 
+  'function_definition > word': 'entity.name.function'
   'command_name': 'entity.name.function'
 
+  'special_variable_name': 'variable.other.member'
   'variable_name': 'variable.other.member'
 
   '"if"': 'keyword.control'
@@ -81,5 +83,6 @@ scopes:
   '"in"': 'keyword.control'
   '"while"': 'keyword.control'
   '"until"': 'keyword.control'
+  '"function"': 'keyword.control'
 
   '"$"': 'punctuation.section.embedded'

--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -1,0 +1,82 @@
+id: 'bash'
+name: 'Bash'
+type: 'tree-sitter'
+parser: 'tree-sitter-bash'
+
+fileTypes: [
+  'sh'
+]
+
+folds: [
+  {
+    type: 'heredoc'
+  }
+  {
+    type: 'if_statement'
+    start: {type: 'then'}
+    end: {index: -1}
+  }
+  {
+    type: 'case_statement'
+    start: {type: 'in'}
+    end: {index: -1}
+  }
+  {
+    type: 'elif_clause'
+    start: {type: 'then'}
+  }
+  {
+    type: 'else_clause'
+    start: {index: 0}
+  }
+  {
+    type: 'case_item'
+    start: {type: ')'}
+  }
+  {
+    type: [
+      'array'
+      'do_group'
+      'subshell'
+      'expansion'
+      'bracket_command'
+      'compound_statement'
+      'process_substitution'
+      'command_substitution'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+]
+
+comments:
+  start: '# '
+
+scopes:
+  'program': 'source.shell'
+
+  'comment': 'comment.block'
+
+  'string': 'string'
+  'raw_string': 'string'
+  'heredoc': 'string'
+
+  'command_name': 'entity.name.function'
+
+  'variable_name': 'variable.other.member'
+
+  '"if"': 'keyword.control'
+  '"fi"': 'keyword.control'
+  '"then"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"elif"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"done"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"esac"': 'keyword.control'
+  '"in"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"until"': 'keyword.control'
+
+  '"$"': 'punctuation.section.embedded'

--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -8,6 +8,8 @@ fileTypes: [
   'sh'
 ]
 
+contentRegExp: '^#!.*\\b(bash|sh)\\r?\\n'
+
 folds: [
   {
     type: 'heredoc'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-shellscript/issues"
   },
   "dependencies": {
-    "tree-sitter-bash": "^0.3.0"
+    "tree-sitter-bash": "^0.4.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/atom/language-shellscript/issues"
   },
+  "dependencies": {
+    "tree-sitter-bash": "^0.3.0"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-shellscript",
-  "version": "0.26.0-1",
+  "version": "0.26.0-2",
   "description": "ShellScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-shellscript",
-  "version": "0.25.4",
+  "version": "0.26.0-0",
   "description": "ShellScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-shellscript",
-  "version": "0.26.0-2",
+  "version": "0.26.0-3",
   "description": "ShellScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-shellscript",
-  "version": "0.26.0-0",
+  "version": "0.26.0-1",
   "description": "ShellScript language support in Atom",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
⚠️ Work In Progress ⚠️

This adds an alternative Bash grammar that uses [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash) for parsing instead of [first-mate](https://github.com/atom/first-mate).