### PR TITLE
Allow whitespace before heredoc token

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -282,7 +282,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(<<)-("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -301,7 +301,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -320,7 +320,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -339,7 +339,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -358,7 +358,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -377,7 +377,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -396,7 +396,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -415,7 +415,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -434,7 +434,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -472,7 +472,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -491,7 +491,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -510,7 +510,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -529,7 +529,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -157,71 +157,78 @@ describe "Shell script grammar", ->
     expect(tokens[10]).toEqual value: ')', scopes: ['source.shell', 'string.quoted.double.shell', 'string.interpolated.dollar.shell', 'punctuation.definition.string.end.shell']
 
   it "tokenizes heredocs", ->
-    delimsByScope =
-      "ruby": "RUBY"
-      "python": "PYTHON"
-      "applescript": "APPLESCRIPT"
-      "shell": "SHELL"
-
-    for scope, delim of delimsByScope
-      tokens = grammar.tokenizeLines """
-        <<#{delim}
-        stuff
-        #{delim}
-      """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-
-      tokens = grammar.tokenizeLines """
-        << #{delim}
-        stuff
-        #{delim}
-      """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell']
-      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-
-      tokens = grammar.tokenizeLines """
-        <<-#{delim}
-        stuff
-        #{delim}
-      """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-
-      tokens = grammar.tokenizeLines """
-        <<- #{delim}
-        stuff
-        #{delim}
-      """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][1]).toEqual value: '- ', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell']
-      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
-
-    delims = [
-      "RANDOMTHING"
-      "RUBY@1.8"
-      "END-INPUT"
+    quotes = [
+      ""
+      '"'
+      "'"
     ]
+    
+    for quote in quotes
+      delimsByScope =
+        "ruby": "RUBY"
+        "python": "PYTHON"
+        "applescript": "APPLESCRIPT"
+        "shell": "SHELL"
 
-    for delim in delims
-      tokens = grammar.tokenizeLines """
-        <<#{delim}
-        stuff
-        #{delim}
-      """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
+      for scope, delim of delimsByScope
+        tokens = grammar.tokenizeLines """
+          <<#{quote}#{delim}#{quote}
+          stuff
+          #{delim}
+        """
+        expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+        expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+        expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+        expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+        tokens = grammar.tokenizeLines """
+          << #{quote}#{delim}#{quote}
+          stuff
+          #{delim}
+        """
+        expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+        expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell']
+        expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+        expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+        expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+        tokens = grammar.tokenizeLines """
+          <<-#{quote}#{delim}#{quote}
+          stuff
+          #{delim}
+        """
+        expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+        expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+        expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+        expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+        tokens = grammar.tokenizeLines """
+          <<- #{quote}#{delim}#{quote}
+          stuff
+          #{delim}
+        """
+        expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.operator.heredoc.shell']
+        expect(tokens[0][1]).toEqual value: '- ', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell']
+        expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+        expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'source.' + scope + '.embedded.shell']
+        expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.no-indent.' + scope + '.shell', 'keyword.control.heredoc-token.shell']
+
+      delims = [
+        "RANDOMTHING"
+        "RUBY@1.8"
+        "END-INPUT"
+      ]
+
+      for delim in delims
+        tokens = grammar.tokenizeLines """
+          <<#{quote}#{delim}#{quote}
+          stuff
+          #{delim}
+        """
+        expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.operator.heredoc.shell']
+        expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
+        expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
+        expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
 
   it "tokenizes shebangs", ->
     {tokens} = grammar.tokenizeLine('#!/bin/sh')


### PR DESCRIPTION


### Description of the Change

A heredoc of the form `<< TOKEN` or `<<- TOKEN` is valid, but not recognised by the Bash grammar. Allow arbitrary whitespace before the token in order to accommodate for these cases.

I've also added tests for quoted tokens.

### Alternate Designs

I'm not sure of any alternates, but I don't know the exact syntactic definition of here documents in shells. This should be broad enough.

### Benefits

Correct highlighting of files that are otherwise correctly parsed by a shell.

### Possible Drawbacks

This may change the highlighting of code that was being correctly highlighted for the wrong reasons?
