### PR TITLE
Tokenize heredocs with leading spaces

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -282,7 +282,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(<<)-("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -301,7 +301,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(RUBY)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -320,7 +320,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -339,7 +339,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(PYTHON)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -358,7 +358,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -377,7 +377,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(APPLESCRIPT)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -396,7 +396,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -415,7 +415,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(HTML)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -434,7 +434,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(MARKDOWN)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -472,7 +472,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -491,7 +491,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(TEXTILE)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -510,7 +510,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -529,7 +529,7 @@
         ]
       }
       {
-        'begin': '(<<)("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*(SHELL)(?=\\s|;|&|<|"|\')\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)-\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -217,6 +217,17 @@ describe "Shell script grammar", ->
       expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
       expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
 
+    for delim in delims
+      tokens = grammar.tokenizeLines """
+        << '#{delim}'
+        stuff
+        #{delim}
+      """
+      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.operator.heredoc.shell']
+      expect(tokens[0][2]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
+      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
+      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
+
   it "tokenizes shebangs", ->
     {tokens} = grammar.tokenizeLine('#!/bin/sh')
     expect(tokens[0]).toEqual value: '#!', scopes: ['source.shell', 'comment.line.number-sign.shebang.shell', 'punctuation.definition.comment.shebang.shell']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Heredocs can contain leading spaces after the `<<`.  Recognize them when the heredoc itself is also quoted.

### Alternate Designs

None.

### Benefits

Spaces before a quoted heredoc identifier should now work.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #103