### PR TITLE
Do not tokenize -# as a comment in argument lists

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -145,7 +145,7 @@
       }
     ]
   'comment':
-    'begin': '(^\\s+)?(?<=^|\\W)(?=#)(?!#{)'
+    'begin': '(^\\s+)?(?<=^|\\W)(?<!-)(?=#)(?!#{)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.shell'

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -249,6 +249,10 @@ describe "Shell script grammar", ->
     expect(tokens[1]).toEqual value: '#', scopes: ['source.shell', 'string.interpolated.backtick.shell', 'comment.line.number-sign.shell', 'punctuation.definition.comment.shell']
     expect(tokens[3]).toEqual value: '`', scopes: ['source.shell', 'string.interpolated.backtick.shell', 'punctuation.definition.string.end.shell']
 
+  it "does not tokenize -# in argument lists as a comment", ->
+    {tokens} = grammar.tokenizeLine('curl -#')
+    expect(tokens[0]).toEqual value: 'curl -#', scopes: ['source.shell']
+
   it "tokenizes nested variable expansions", ->
     {tokens} = grammar.tokenizeLine('${${C}}')
     expect(tokens[0]).toEqual value: '${', scopes: ['source.shell', 'variable.other.bracket.shell', 'punctuation.definition.variable.shell']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

https://www.gnu.org/software/bash/manual/html_node/Comments.html states that `#` only starts comments if it starts a word.  While this isn't strictly true (e.g. `# hello` is a comment) that still rules out `-#` as a comment.  Therefore add a lookbehind to make sure a dash does not precede a possible comment.

### Alternate Designs

Refactor comment regex to try to match the above reference better.

### Benefits

The curl `-#` argument should no longer make the rest of the line a comment.

### Possible Drawbacks

I don't really see any.

### Applicable Issues

Fixes #104