### PR TITLE
⬆️ tree-sitter-bash@0.13.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/atom/language-shellscript/issues"
   },
   "dependencies": {
-    "tree-sitter-bash": "^0.13.8"
+    "tree-sitter-bash": "^0.13.9"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
tree-sitter-bash@0.13.9 introduces a fix for Tree-sitter users experiencing the issue described in https://github.com/atom/language-shellscript/issues/139. (If you're not using Tree-sitter, and you're instead using the old Textmate grammar, you'll still see the issue.)

----

*List of changes between `tree-sitter-bash@0.13.8` and `tree-sitter-bash@0.13.9`: https://github.com/tree-sitter/tree-sitter-bash/compare/v0.13.8...v0.13.9*