### PR TITLE
Support ANSII-C escaped strings in Bash

### DIFF
--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -79,6 +79,7 @@ scopes:
 
   'string': 'string'
   'raw_string': 'string'
+  'ansii_c_string': 'string'
   'heredoc_body': 'string'
   'heredoc_start': 'string'
   'regex': 'string.regexp'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/atom/language-shellscript/issues"
   },
   "dependencies": {
-    "tree-sitter-bash": "^0.15.0"
+    "tree-sitter-bash": "^0.16.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
Fixes #146
Depends on https://github.com/tree-sitter/tree-sitter-bash/pull/54, which also contains more information.