### PR TITLE
Fix heredoc expansion

### DIFF
--- a/grammars/shell-unix-bash.cson
+++ b/grammars/shell-unix-bash.cson
@@ -548,7 +548,7 @@
         ]
       }
       {
-        'begin': '(<<)-\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)-\\s*("|\')\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -561,7 +561,7 @@
         'name': 'string.unquoted.heredoc.no-indent.shell'
       }
       {
-        'begin': '(<<)\\s*("|\'|)\\s*\\\\?([^;&<\\s]+)\\2'
+        'begin': '(<<)\\s*("|\')\\s*\\\\?([^;&<\\s]+)\\2'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.heredoc.shell'
@@ -572,6 +572,56 @@
           '1':
             'name': 'keyword.control.heredoc-token.shell'
         'name': 'string.unquoted.heredoc.shell'
+      }
+      {
+        'begin': '(<<)-\\s*\\\\?([^;&<\\s]+)'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.operator.heredoc.shell'
+          '2':
+            'name': 'keyword.control.heredoc-token.shell'
+        'end': '^\\t*(\\2)(?=\\s|;|&|$)'
+        'endCaptures':
+          '1':
+            'name': 'keyword.control.heredoc-token.shell'
+        'name': 'string.unquoted.heredoc.expanded.no-indent.shell'
+        'patterns': [
+          {
+            'match': '\\\\[\\$`\\\\\\n]'
+            'name': 'constant.character.escape.shell'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#interpolation'
+          }
+        ]
+      }
+      {
+        'begin': '(<<)\\s*\\\\?([^;&<\\s]+)'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.operator.heredoc.shell'
+          '2':
+            'name': 'keyword.control.heredoc-token.shell'
+        'end': '^(\\2)(?=\\s|;|&|$)'
+        'endCaptures':
+          '1':
+            'name': 'keyword.control.heredoc-token.shell'
+        'name': 'string.unquoted.heredoc.expanded.shell'
+        'patterns': [
+          {
+            'match': '\\\\[\\$`\\\\\\n]'
+            'name': 'constant.character.escape.shell'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#interpolation'
+          }
+        ]
       }
     ]
   'herestring':

--- a/spec/shell-unix-bash-spec.coffee
+++ b/spec/shell-unix-bash-spec.coffee
@@ -220,10 +220,10 @@ describe "Shell script grammar", ->
         stuff
         #{delim}
       """
-      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.operator.heredoc.shell']
-      expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
-      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.shell']
-      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.shell', 'keyword.control.heredoc-token.shell']
+      expect(tokens[0][0]).toEqual value: '<<', scopes: ['source.shell', 'string.unquoted.heredoc.expanded.shell', 'keyword.operator.heredoc.shell']
+      expect(tokens[0][1]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.expanded.shell', 'keyword.control.heredoc-token.shell']
+      expect(tokens[1][0]).toEqual value: 'stuff', scopes: ['source.shell', 'string.unquoted.heredoc.expanded.shell']
+      expect(tokens[2][0]).toEqual value: delim, scopes: ['source.shell', 'string.unquoted.heredoc.expanded.shell', 'keyword.control.heredoc-token.shell']
 
     for delim in delims
       tokens = grammar.tokenizeLines """


### PR DESCRIPTION
### Description of the Change

Add support for recognizing expansions in heredocs. The `begin` regexes of the existing rules are modified to not match the expanded form (which doesn't have quotes, see [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07_04)). New rules for the expanded form are added that are identical to the existing ones minus the quotes. The `patterns` are taken from `'string'` (minus the quotes).

### Alternate Designs

None

### Benefits

Variables in shell script heredocs will be correctly highlighted.

### Possible Drawbacks

None

### Applicable Issues

#151
