### PR TITLE
Updated sh section to use /usr/bin/env

### DIFF
--- a/snippets/language-shellscript.cson
+++ b/snippets/language-shellscript.cson
@@ -7,7 +7,7 @@
     'body': '#!/usr/bin/env bash\n'
   '#!/bin/sh':
     'prefix': 'sh'
-    'body': '#!/bin/sh\n'
+    'body': '#!/usr/bin/env sh\n'
   '#!/usr/bin/env zsh':
     'prefix': 'zsh'
     'body': '#!/usr/bin/env zsh\n'


### PR DESCRIPTION
The `sh` section currently autofills to `/bin/sh`. This just changes it to fill to `/usr/bin/env sh` to align with the other options.

### Benefits

Uniformity when autocompleting a shell shebang. All other listed shells go to `/usr/bin/env`, so it likewise made sense that `sh` should as well.