### PR TITLE
Handle files with first line shell opts.

### DIFF
--- a/grammars/tree-sitter-bash.cson
+++ b/grammars/tree-sitter-bash.cson
@@ -12,7 +12,7 @@ injectionRegex: '^(bash|sh|BASH|SH)$'
 
 firstLineRegex: [
   # shebang line
-  '^#!.*\\b(bash|sh)\\r?\\n'
+  '^#!.*\\b(bash|sh)(\\r?\\n|\\s)'
 
   # vim modeline
   'vim\\b.*\\bset\\b.*\\b(filetype|ft|syntax)=(sh|bash)'


### PR DESCRIPTION
This should match:
```
#!/bin/bash
```
and
```
#!/bin/bash -eu
```
Currently the latter isn't being matched because the regex requires a new line after `sh` or `bash`.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
